### PR TITLE
chore: add ci integration file

### DIFF
--- a/.github/workflows/intergration.yml
+++ b/.github/workflows/intergration.yml
@@ -1,0 +1,54 @@
+name: Continuous Integration
+
+on:
+  workflow_dispatch:
+  push:
+    branches: [main]
+    paths:
+      - apps/*
+      - packages/*
+  pull_request:
+    branches: [main]
+    paths:
+      - apps/*
+      - packages/*
+
+permissions:
+  contents: read
+
+jobs:
+  lint:
+    name: Lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+      - name: Setup Mise
+        uses: jdx/mise-action@v2
+      - name: Install Dependencies
+        run: mise x -- pnpm install
+      - name: Run Linter
+        run: mise x -- pnpm lint
+
+  test:
+    name: Test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+      - name: Setup Mise
+        uses: jdx/mise-action@v2
+      - name: Install Dependencies
+        run: mise x -- pnpm install
+      - name: Run Tests
+        run: mise x -- pnpm test --affected
+      - name: Merge Coverage Reports
+        run: mise x -- pnpm turbo merge-json-reports
+      - name: Upload Coverage to Codecov
+        uses: codecov/codecov-action@v5
+        with:
+          files: ./packages/vitest-config/coverage/merged/merged-coverage.json
+          flags: unittests
+          name: Envy Codecov Report
+          verbose: true
+          token: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
This pull request adds a continuous integration (CI) workflow to the repository using GitHub Actions. The workflow is triggered on pushes and pull requests to the `main` branch, and it runs linting and testing jobs for changes in the `apps` and `packages` directories.

Continuous Integration Workflow:

* Introduced a new GitHub Actions workflow (`.github/workflows/intergration.yml`) that runs on pushes and pull requests to the `main` branch, focusing on changes within `apps` and `packages`.

Linting and Testing Automation:

* Added a `lint` job that checks out the code, sets up the environment using Mise, installs dependencies with `pnpm`, and runs the linter.
* Added a `test` job that checks out the code (with full history), sets up the environment, installs dependencies, runs affected tests, merges coverage reports, and uploads the merged coverage to Codecov.