### PR TITLE
Feat/dashboard page

### DIFF
--- a/apps/web/__mocks__/lucide-react.tsx
+++ b/apps/web/__mocks__/lucide-react.tsx
@@ -32,3 +32,36 @@ export const Lock = React.forwardRef<
 ));
 
 Lock.displayName = "Lock";
+
+export const Building2 = React.forwardRef<
+	SVGSVGElement,
+	React.SVGProps<SVGSVGElement>
+>((props, ref) => (
+	<svg ref={ref} data-testid="building-icon" {...props}>
+		<title>Building2</title>
+	</svg>
+));
+
+Building2.displayName = "Building2";
+
+export const Users = React.forwardRef<
+	SVGSVGElement,
+	React.SVGProps<SVGSVGElement>
+>((props, ref) => (
+	<svg ref={ref} data-testid="users-icon" {...props}>
+		<title>Users</title>
+	</svg>
+));
+
+Users.displayName = "Users";
+
+export const FolderGit2 = React.forwardRef<
+	SVGSVGElement,
+	React.SVGProps<SVGSVGElement>
+>((props, ref) => (
+	<svg ref={ref} data-testid="git-folder-icon" {...props}>
+		<title>FolderGit2</title>
+	</svg>
+));
+
+FolderGit2.displayName = "FolderGit2";

--- a/apps/web/__mocks__/lucide-react.tsx
+++ b/apps/web/__mocks__/lucide-react.tsx
@@ -65,3 +65,14 @@ export const FolderGit2 = React.forwardRef<
 ));
 
 FolderGit2.displayName = "FolderGit2";
+
+export const Variable = React.forwardRef<
+	SVGSVGElement,
+	React.SVGProps<SVGSVGElement>
+>((props, ref) => (
+	<svg ref={ref} data-testid="variable-icon" {...props}>
+		<title>Variable</title>
+	</svg>
+));
+
+Variable.displayName = "Variable";

--- a/apps/web/src/app/(internal)/dashboard/__mocks__/organizations-card.tsx
+++ b/apps/web/src/app/(internal)/dashboard/__mocks__/organizations-card.tsx
@@ -1,0 +1,7 @@
+export default function MockOrganizationsCard(props: any) {
+	return (
+		<div data-testid="organizations-card" {...props}>
+			Organizations Card
+		</div>
+	);
+}

--- a/apps/web/src/app/(internal)/dashboard/__mocks__/projects-card.tsx
+++ b/apps/web/src/app/(internal)/dashboard/__mocks__/projects-card.tsx
@@ -1,0 +1,7 @@
+export default function MockProjectsCard(props: any) {
+	return (
+		<div data-testid="projects-card" {...props}>
+			Projects Card
+		</div>
+	);
+}

--- a/apps/web/src/app/(internal)/dashboard/__mocks__/stats-card.tsx
+++ b/apps/web/src/app/(internal)/dashboard/__mocks__/stats-card.tsx
@@ -1,0 +1,7 @@
+export default function StatsCard(props: any) {
+	return (
+		<div data-testid="stats-card" {...props}>
+			Stats Card
+		</div>
+	);
+}

--- a/apps/web/src/app/(internal)/dashboard/__mocks__/teams-card.tsx
+++ b/apps/web/src/app/(internal)/dashboard/__mocks__/teams-card.tsx
@@ -1,0 +1,7 @@
+export default function MockTeamsCard(props: any) {
+	return (
+		<div data-testid="teams-card" {...props}>
+			Teams Card
+		</div>
+	);
+}

--- a/apps/web/src/app/(internal)/dashboard/organizations-card.test.tsx
+++ b/apps/web/src/app/(internal)/dashboard/organizations-card.test.tsx
@@ -1,0 +1,44 @@
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it } from "vitest";
+import OrganizationsCard, {
+	type OrganizationsCardProps,
+} from "./organizations-card";
+
+describe("OrganizationsCard", () => {
+	afterEach(() => {
+		cleanup();
+	});
+
+	describe("Rendering Tests", () => {
+		it("renders the card with provided props", () => {
+			const props: OrganizationsCardProps = {
+				title: "Organizations",
+				description: "Your organization overview",
+				organizations: [
+					{ id: 1, name: "Org One", teams: 5, projects: 10 },
+					{ id: 2, name: "Org Two", teams: 3, projects: 7 },
+				],
+			};
+
+			render(<OrganizationsCard {...props} />);
+
+			const title = screen.getByTestId("card-title");
+			expect(title).toBeInTheDocument();
+			expect(title).toHaveTextContent(props.title);
+
+			const description = screen.getByTestId("card-description");
+			expect(description).toBeInTheDocument();
+			expect(description).toHaveTextContent(props.description);
+
+			const content = screen.getByTestId("card-content");
+
+			expect(content).toBeInTheDocument();
+			props.organizations.forEach((org) => {
+				expect(content).toHaveTextContent(org.name);
+				expect(content).toHaveTextContent(
+					`${org.teams} teams | ${org.projects} projects`,
+				);
+			});
+		});
+	});
+});

--- a/apps/web/src/app/(internal)/dashboard/organizations-card.tsx
+++ b/apps/web/src/app/(internal)/dashboard/organizations-card.tsx
@@ -1,0 +1,59 @@
+import {
+	Card,
+	CardContent,
+	CardDescription,
+	CardHeader,
+	CardTitle,
+} from "@repo/shadcn/components/card";
+import { Building2 } from "lucide-react";
+
+export interface OrganizationsCardProps {
+	title: string;
+	description: string;
+	organizations: {
+		// Replace with actual organization data type
+		id: number;
+		name: string;
+		teams: number;
+		projects: number;
+	}[];
+}
+
+export default function OrganizationsCard({
+	title,
+	description,
+	organizations,
+}: OrganizationsCardProps) {
+	return (
+		<Card>
+			<CardHeader>
+				<CardTitle className="text-foreground">{title}</CardTitle>
+				<CardDescription>{description}</CardDescription>
+			</CardHeader>
+			<CardContent>
+				<div className="space-y-3">
+					{organizations.map((org) => (
+						<div
+							key={org.id}
+							className="flex items-center justify-between p-3 rounded-lg border border-border bg-card hover:bg-accent/50 transition-colors"
+						>
+							<div className="flex items-center gap-3">
+								<div className="h-8 w-8 rounded-lg bg-muted flex items-center justify-center">
+									<Building2 className="h-4 w-4 text-muted-foreground" />
+								</div>
+								<div>
+									<p className="text-sm font-medium text-foreground">
+										{org.name}
+									</p>
+									<p className="text-xs text-muted-foreground">
+										{org.teams} teams | {org.projects} projects
+									</p>
+								</div>
+							</div>
+						</div>
+					))}
+				</div>
+			</CardContent>
+		</Card>
+	);
+}

--- a/apps/web/src/app/(internal)/dashboard/page.test.tsx
+++ b/apps/web/src/app/(internal)/dashboard/page.test.tsx
@@ -1,0 +1,70 @@
+import { cleanup, render, screen } from "@testing-library/react";
+import { i } from "node_modules/vitest/dist/chunks/moduleRunner.d.CzOZ_4wC";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import Dashboard, { getIcon } from "./page";
+
+vi.mock("@/lib/utils");
+vi.mock("./organizations-card");
+vi.mock("./projects-card");
+vi.mock("./stats-card");
+vi.mock("./teams-card");
+
+describe("Dashboard Page", () => {
+	afterEach(() => {
+		cleanup();
+	});
+
+	describe("Rendering Tests", () => {
+		it("should render the dashboard page", () => {
+			render(<Dashboard />);
+			const dashboardElement = screen.getByTestId("dashboard");
+			expect(dashboardElement).toBeInTheDocument();
+		});
+
+		it("should render dashboard header", () => {
+			render(<Dashboard />);
+			const headerElement = screen.getByText(
+				/Overview of your environment variables and secrets/i,
+			);
+			expect(headerElement).toBeInTheDocument();
+		});
+
+		it("should render stats cards", () => {
+			render(<Dashboard />);
+			const statsCardElements = screen.getAllByTestId("stats-card");
+			expect(statsCardElements.length).toBeGreaterThanOrEqual(1); // At least one stats card should be rendered
+		});
+
+		it("should render projects card", () => {
+			render(<Dashboard />);
+			const projectsCardElement = screen.getByTestId("projects-card");
+			expect(projectsCardElement).toBeInTheDocument();
+		});
+
+		it("should render organizations card", () => {
+			render(<Dashboard />);
+			const organizationsCardElement = screen.getByTestId("organizations-card");
+			expect(organizationsCardElement).toBeInTheDocument();
+		});
+
+		it("should render teams card", () => {
+			render(<Dashboard />);
+			const teamsCardElement = screen.getByTestId("teams-card");
+			expect(teamsCardElement).toBeInTheDocument();
+		});
+	});
+});
+
+describe("getIcon Utility Function", () => {
+	it.each([
+		{ key: "organizations", expectedIconTestId: "building-icon" },
+		{ key: "projects", expectedIconTestId: "git-folder-icon" },
+		{ key: "teams", expectedIconTestId: "users-icon" },
+		{ key: "unknown", expectedIconTestId: "variable-icon" }, // Default case
+	])("should return correct icon", ({ key, expectedIconTestId }) => {
+		const IconComponent = getIcon(key);
+		const { getByTestId } = render(IconComponent);
+		const iconElement = getByTestId(expectedIconTestId);
+		expect(iconElement).toBeInTheDocument();
+	});
+});

--- a/apps/web/src/app/(internal)/dashboard/page.tsx
+++ b/apps/web/src/app/(internal)/dashboard/page.tsx
@@ -1,9 +1,188 @@
+import {
+	Card,
+	CardContent,
+	CardDescription,
+	CardHeader,
+	CardTitle,
+} from "@repo/shadcn/components/card";
+import { Building2, FolderGit2, Key, Users, Variable } from "lucide-react";
 import { ContentLayout } from "@/components/admin-panel/content-layout";
+import { capitalize } from "@/lib/utils";
+import StatsCard from "./stats-card";
 
 export default function Dashboard() {
+	// Mock dashboard data
+	const stats = {
+		organizations: 3,
+		teams: 8,
+		projects: 12,
+		variables: 247,
+	};
+
+	const recentOrganizations = [
+		{ id: 1, name: "Acme Corp", teams: 4, projects: 8 },
+		{ id: 2, name: "TechStart Inc", teams: 2, projects: 3 },
+		{ id: 3, name: "DevOps LLC", teams: 2, projects: 1 },
+		{ id: 4, name: "Startup LLC", teams: 5, projects: 3 },
+	];
+
+	const recentTeams = [
+		{ id: 1, name: "Frontend Team", org: "Acme Corp", members: 5 },
+		{ id: 2, name: "Backend Team", org: "Acme Corp", members: 4 },
+		{ id: 3, name: "DevOps Team", org: "TechStart Inc", members: 3 },
+		{ id: 4, name: "Mobile Team", org: "Acme Corp", members: 6 },
+	];
+
+	const recentProjects = [
+		{ id: 1, name: "web-dashboard", team: "Frontend Team", variables: 32 },
+		{ id: 2, name: "api-service", team: "Backend Team", variables: 45 },
+		{ id: 3, name: "mobile-app", team: "Mobile Team", variables: 28 },
+		{ id: 4, name: "infrastructure", team: "DevOps Team", variables: 67 },
+	];
+
 	return (
 		<ContentLayout title="Dashboard">
-			<h1>Welcome to the Dashboard</h1>
+			<div className="min-h-screen bg-background">
+				<div className="container mx-auto px-4 py-8 max-w-7xl">
+					{/* Header */}
+					<div className="mb-8">
+						<p className="text-muted-foreground">
+							Overview of your environment variables and secrets
+						</p>
+					</div>
+
+					{/* Stats Grid */}
+					<div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-4 mb-8">
+						{/* Loop through returned stats */}
+						{Object.entries(stats).map(([key, value]) => (
+							<StatsCard
+								key={key}
+								title={capitalize(key)}
+								value={value}
+								icon={getIconStatIcon(key)}
+							/>
+						))}
+					</div>
+
+					{/* Content Grid */}
+					<div className="grid grid-cols-1 gap-4 lg:grid-cols-2">
+						{/* Organizations */}
+						<Card>
+							<CardHeader>
+								<CardTitle className="text-foreground">Organizations</CardTitle>
+								<CardDescription>Your organization overview</CardDescription>
+							</CardHeader>
+							<CardContent>
+								<div className="space-y-3">
+									{recentOrganizations.map((org) => (
+										<div
+											key={org.id}
+											className="flex items-center justify-between p-3 rounded-lg border border-border bg-card hover:bg-accent/50 transition-colors"
+										>
+											<div className="flex items-center gap-3">
+												<div className="h-8 w-8 rounded-lg bg-muted flex items-center justify-center">
+													<Building2 className="h-4 w-4 text-muted-foreground" />
+												</div>
+												<div>
+													<p className="text-sm font-medium text-foreground">
+														{org.name}
+													</p>
+													<p className="text-xs text-muted-foreground">
+														{org.teams} teams | {org.projects} projects
+													</p>
+												</div>
+											</div>
+										</div>
+									))}
+								</div>
+							</CardContent>
+						</Card>
+
+						{/* Teams */}
+						<Card>
+							<CardHeader>
+								<CardTitle className="text-foreground">Teams</CardTitle>
+								<CardDescription>Recent teams</CardDescription>
+							</CardHeader>
+							<CardContent>
+								<div className="space-y-3">
+									{recentTeams.map((team) => (
+										<div
+											key={team.id}
+											className="flex items-center justify-between p-3 rounded-lg border border-border bg-card hover:bg-accent/50 transition-colors"
+										>
+											<div className="flex items-center gap-3">
+												<div className="h-8 w-8 rounded-lg bg-muted flex items-center justify-center">
+													<Users className="h-4 w-4 text-muted-foreground" />
+												</div>
+												<div>
+													<p className="text-sm font-medium text-foreground">
+														{team.name}
+													</p>
+													<p className="text-xs text-muted-foreground">
+														{team.org} | {team.members} members
+													</p>
+												</div>
+											</div>
+										</div>
+									))}
+								</div>
+							</CardContent>
+						</Card>
+
+						{/* Projects */}
+						<Card className="lg:col-span-2">
+							<CardHeader>
+								<CardTitle className="text-foreground">Projects</CardTitle>
+								<CardDescription>Recent projects</CardDescription>
+							</CardHeader>
+							<CardContent>
+								<div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
+									{recentProjects.map((project) => (
+										<div
+											key={project.id}
+											className="flex items-center justify-between p-3 rounded-lg border border-border bg-card hover:bg-accent/50 transition-colors"
+										>
+											<div className="flex items-center gap-3">
+												<div className="h-8 w-8 rounded-lg bg-muted flex items-center justify-center">
+													<FolderGit2 className="h-4 w-4 text-muted-foreground" />
+												</div>
+												<div>
+													<p className="text-sm font-medium text-foreground font-mono">
+														{project.name}
+													</p>
+													<p className="text-xs text-muted-foreground">
+														{project.team} · {project.variables} vars
+													</p>
+												</div>
+											</div>
+										</div>
+									))}
+								</div>
+							</CardContent>
+						</Card>
+					</div>
+				</div>
+			</div>
 		</ContentLayout>
 	);
+}
+
+/**
+ * Get the corresponding icon component for a given stat title.
+ *
+ * @param title title of the stat
+ * @returns corresponding icon component
+ */
+export function getIconStatIcon(title: string) {
+	switch (title) {
+		case "organizations":
+			return <Building2 className="h-4 w-4 text-muted-foreground" />;
+		case "teams":
+			return <Users className="h-4 w-4 text-muted-foreground" />;
+		case "projects":
+			return <FolderGit2 className="h-4 w-4 text-muted-foreground" />;
+		default:
+			return <Variable className="h-4 w-4 text-muted-foreground" />;
+	}
 }

--- a/apps/web/src/app/(internal)/dashboard/page.tsx
+++ b/apps/web/src/app/(internal)/dashboard/page.tsx
@@ -38,7 +38,7 @@ export default function Dashboard() {
 
 	return (
 		<ContentLayout title="Dashboard">
-			<div className="min-h-screen bg-background">
+			<div data-testid="dashboard" className="min-h-screen bg-background">
 				<div className="container mx-auto px-4 py-8 max-w-7xl">
 					{/* Header */}
 					<div className="mb-8">

--- a/apps/web/src/app/(internal)/dashboard/page.tsx
+++ b/apps/web/src/app/(internal)/dashboard/page.tsx
@@ -1,19 +1,15 @@
-import {
-	Card,
-	CardContent,
-	CardDescription,
-	CardHeader,
-	CardTitle,
-} from "@repo/shadcn/components/card";
-import { Building2, FolderGit2, Key, Users, Variable } from "lucide-react";
+import { Building2, FolderGit2, Users, Variable } from "lucide-react";
 import { ContentLayout } from "@/components/admin-panel/content-layout";
 import { capitalize } from "@/lib/utils";
+import OrganizationsCard from "./organizations-card";
+import ProjectsCard from "./projects-card";
 import StatsCard from "./stats-card";
+import TeamsCard from "./teams-card";
 
 export default function Dashboard() {
 	// Mock dashboard data
 	const stats = {
-		organizations: 3,
+		organizations: 4,
 		teams: 8,
 		projects: 12,
 		variables: 247,
@@ -59,108 +55,30 @@ export default function Dashboard() {
 								key={key}
 								title={capitalize(key)}
 								value={value}
-								icon={getIconStatIcon(key)}
+								icon={getIcon(key)}
 							/>
 						))}
 					</div>
 
 					{/* Content Grid */}
 					<div className="grid grid-cols-1 gap-4 lg:grid-cols-2">
-						{/* Organizations */}
-						<Card>
-							<CardHeader>
-								<CardTitle className="text-foreground">Organizations</CardTitle>
-								<CardDescription>Your organization overview</CardDescription>
-							</CardHeader>
-							<CardContent>
-								<div className="space-y-3">
-									{recentOrganizations.map((org) => (
-										<div
-											key={org.id}
-											className="flex items-center justify-between p-3 rounded-lg border border-border bg-card hover:bg-accent/50 transition-colors"
-										>
-											<div className="flex items-center gap-3">
-												<div className="h-8 w-8 rounded-lg bg-muted flex items-center justify-center">
-													<Building2 className="h-4 w-4 text-muted-foreground" />
-												</div>
-												<div>
-													<p className="text-sm font-medium text-foreground">
-														{org.name}
-													</p>
-													<p className="text-xs text-muted-foreground">
-														{org.teams} teams | {org.projects} projects
-													</p>
-												</div>
-											</div>
-										</div>
-									))}
-								</div>
-							</CardContent>
-						</Card>
+						<OrganizationsCard
+							title="Organizations"
+							description="Your organization overview"
+							organizations={recentOrganizations}
+						/>
 
-						{/* Teams */}
-						<Card>
-							<CardHeader>
-								<CardTitle className="text-foreground">Teams</CardTitle>
-								<CardDescription>Recent teams</CardDescription>
-							</CardHeader>
-							<CardContent>
-								<div className="space-y-3">
-									{recentTeams.map((team) => (
-										<div
-											key={team.id}
-											className="flex items-center justify-between p-3 rounded-lg border border-border bg-card hover:bg-accent/50 transition-colors"
-										>
-											<div className="flex items-center gap-3">
-												<div className="h-8 w-8 rounded-lg bg-muted flex items-center justify-center">
-													<Users className="h-4 w-4 text-muted-foreground" />
-												</div>
-												<div>
-													<p className="text-sm font-medium text-foreground">
-														{team.name}
-													</p>
-													<p className="text-xs text-muted-foreground">
-														{team.org} | {team.members} members
-													</p>
-												</div>
-											</div>
-										</div>
-									))}
-								</div>
-							</CardContent>
-						</Card>
+						<TeamsCard
+							title="Teams"
+							description="Recent teams"
+							teams={recentTeams}
+						/>
 
-						{/* Projects */}
-						<Card className="lg:col-span-2">
-							<CardHeader>
-								<CardTitle className="text-foreground">Projects</CardTitle>
-								<CardDescription>Recent projects</CardDescription>
-							</CardHeader>
-							<CardContent>
-								<div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
-									{recentProjects.map((project) => (
-										<div
-											key={project.id}
-											className="flex items-center justify-between p-3 rounded-lg border border-border bg-card hover:bg-accent/50 transition-colors"
-										>
-											<div className="flex items-center gap-3">
-												<div className="h-8 w-8 rounded-lg bg-muted flex items-center justify-center">
-													<FolderGit2 className="h-4 w-4 text-muted-foreground" />
-												</div>
-												<div>
-													<p className="text-sm font-medium text-foreground font-mono">
-														{project.name}
-													</p>
-													<p className="text-xs text-muted-foreground">
-														{project.team} · {project.variables} vars
-													</p>
-												</div>
-											</div>
-										</div>
-									))}
-								</div>
-							</CardContent>
-						</Card>
+						<ProjectsCard
+							title="Projects"
+							description="Recent projects"
+							projects={recentProjects}
+						/>
 					</div>
 				</div>
 			</div>
@@ -174,7 +92,7 @@ export default function Dashboard() {
  * @param title title of the stat
  * @returns corresponding icon component
  */
-export function getIconStatIcon(title: string) {
+export function getIcon(title: string) {
 	switch (title) {
 		case "organizations":
 			return <Building2 className="h-4 w-4 text-muted-foreground" />;

--- a/apps/web/src/app/(internal)/dashboard/projects-card.test.tsx
+++ b/apps/web/src/app/(internal)/dashboard/projects-card.test.tsx
@@ -1,0 +1,45 @@
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it } from "vitest";
+import ProjectsCard, { type ProjectsCardProps } from "./projects-card";
+
+describe("ProjectsCard", () => {
+	afterEach(() => {
+		cleanup();
+	});
+
+	describe("Rendering Tests", () => {
+		it("renders the card with provided props", () => {
+			const props: ProjectsCardProps = {
+				title: "Projects",
+				description: "Your project overview",
+				projects: [
+					{ id: 1, name: "Project One", team: "Team A", variables: 15 },
+					{ id: 2, name: "Project Two", team: "Team B", variables: 8 },
+				],
+			};
+
+			render(<ProjectsCard {...props} />);
+
+			const title = screen.getByTestId("card-title");
+			expect(title).toBeInTheDocument();
+			expect(title).toHaveTextContent(props.title);
+
+			const description = screen.getByTestId("card-description");
+			expect(description).toBeInTheDocument();
+			expect(description).toHaveTextContent(props.description);
+
+			const content = screen.getByTestId("card-content");
+			expect(content).toBeInTheDocument();
+
+			props.projects.forEach((project) => {
+				const projectName = screen.getByText(project.name);
+				expect(projectName).toBeInTheDocument();
+
+				const projectDetails = screen.getByText(
+					`${project.team} | ${project.variables} vars`,
+				);
+				expect(projectDetails).toBeInTheDocument();
+			});
+		});
+	});
+});

--- a/apps/web/src/app/(internal)/dashboard/projects-card.tsx
+++ b/apps/web/src/app/(internal)/dashboard/projects-card.tsx
@@ -1,0 +1,59 @@
+import {
+	Card,
+	CardContent,
+	CardDescription,
+	CardHeader,
+	CardTitle,
+} from "@repo/shadcn/components/card";
+import { FolderGit2 } from "lucide-react";
+
+export interface ProjectsCardProps {
+	title: string;
+	description: string;
+	projects: {
+		// Replace with actual project data type
+		id: number;
+		name: string;
+		team: string;
+		variables: number;
+	}[];
+}
+
+export default function ProjectsCard({
+	title,
+	description,
+	projects,
+}: ProjectsCardProps) {
+	return (
+		<Card className="lg:col-span-2">
+			<CardHeader>
+				<CardTitle className="text-foreground">{title}</CardTitle>
+				<CardDescription>{description}</CardDescription>
+			</CardHeader>
+			<CardContent>
+				<div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
+					{projects.map((project) => (
+						<div
+							key={project.id}
+							className="flex items-center justify-between p-3 rounded-lg border border-border bg-card hover:bg-accent/50 transition-colors"
+						>
+							<div className="flex items-center gap-3">
+								<div className="h-8 w-8 rounded-lg bg-muted flex items-center justify-center">
+									<FolderGit2 className="h-4 w-4 text-muted-foreground" />
+								</div>
+								<div>
+									<p className="text-sm font-medium text-foreground font-mono">
+										{project.name}
+									</p>
+									<p className="text-xs text-muted-foreground">
+										{project.team} | {project.variables} vars
+									</p>
+								</div>
+							</div>
+						</div>
+					))}
+				</div>
+			</CardContent>
+		</Card>
+	);
+}

--- a/apps/web/src/app/(internal)/dashboard/stats-card.test.tsx
+++ b/apps/web/src/app/(internal)/dashboard/stats-card.test.tsx
@@ -1,0 +1,15 @@
+import { cleanup, render, screen } from "@testing-library/react";
+import { expect, test } from "vitest";
+import StatsCard from "./stats-card";
+
+test("should render the StatsCard component", () => {
+	const title = "test title";
+	const value = 1234;
+	const icon = <svg data-testid="test-icon" />;
+
+	render(<StatsCard title={title} value={value} icon={icon} />);
+
+	expect(screen.getByText(title)).toBeInTheDocument();
+	expect(screen.getByText(value.toString())).toBeInTheDocument();
+	expect(screen.getByTestId("test-icon")).toBeInTheDocument();
+});

--- a/apps/web/src/app/(internal)/dashboard/stats-card.tsx
+++ b/apps/web/src/app/(internal)/dashboard/stats-card.tsx
@@ -1,0 +1,29 @@
+import {
+	Card,
+	CardContent,
+	CardHeader,
+	CardTitle,
+} from "@repo/shadcn/components/card";
+
+interface StatCardProps {
+	title: string;
+	icon: React.ReactNode;
+	value: number;
+}
+
+export default function StatsCard({ title, icon, value }: StatCardProps) {
+	return (
+		<Card>
+			<CardHeader className="flex flex-row items-center justify-between pb-2">
+				<CardTitle className="text-sm font-medium text-muted-foreground">
+					{title}
+				</CardTitle>
+				{icon}
+				{/* <Building2 className="h-4 w-4 text-muted-foreground" /> */}
+			</CardHeader>
+			<CardContent>
+				<div className="text-2xl font-semibold text-foreground">{value}</div>
+			</CardContent>
+		</Card>
+	);
+}

--- a/apps/web/src/app/(internal)/dashboard/teams-card.test.tsx
+++ b/apps/web/src/app/(internal)/dashboard/teams-card.test.tsx
@@ -1,0 +1,42 @@
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it } from "vitest";
+import TeamsCard, { type TeamsCardProps } from "./teams-card";
+
+describe("TeamsCard", () => {
+	afterEach(() => {
+		cleanup();
+	});
+
+	describe("Rendering Tests", () => {
+		it("renders the card with provided props", () => {
+			const props: TeamsCardProps = {
+				title: "Teams",
+				description: "Your team overview",
+				teams: [
+					{ id: 1, name: "Team Alpha", org: "Org One", members: 8 },
+					{ id: 2, name: "Team Beta", org: "Org Two", members: 12 },
+				],
+			};
+
+			render(<TeamsCard {...props} />);
+
+			const title = screen.getByTestId("card-title");
+			expect(title).toBeInTheDocument();
+			expect(title).toHaveTextContent(props.title);
+
+			const description = screen.getByTestId("card-description");
+			expect(description).toBeInTheDocument();
+			expect(description).toHaveTextContent(props.description);
+
+			const content = screen.getByTestId("card-content");
+
+			expect(content).toBeInTheDocument();
+			props.teams.forEach((team) => {
+				expect(content).toHaveTextContent(team.name);
+				expect(content).toHaveTextContent(
+					`${team.org} | ${team.members} members`,
+				);
+			});
+		});
+	});
+});

--- a/apps/web/src/app/(internal)/dashboard/teams-card.tsx
+++ b/apps/web/src/app/(internal)/dashboard/teams-card.tsx
@@ -1,0 +1,59 @@
+import {
+	Card,
+	CardContent,
+	CardDescription,
+	CardHeader,
+	CardTitle,
+} from "@repo/shadcn/components/card";
+import { Users } from "lucide-react";
+
+export interface TeamsCardProps {
+	title: string;
+	description: string;
+	teams: {
+		// Replace with actual team data type
+		id: number;
+		name: string;
+		org: string;
+		members: number;
+	}[];
+}
+
+export default function TeamsCard({
+	title,
+	description,
+	teams,
+}: TeamsCardProps) {
+	return (
+		<Card>
+			<CardHeader>
+				<CardTitle className="text-foreground">{title}</CardTitle>
+				<CardDescription>{description}</CardDescription>
+			</CardHeader>
+			<CardContent>
+				<div className="space-y-3">
+					{teams.map((team) => (
+						<div
+							key={team.id}
+							className="flex items-center justify-between p-3 rounded-lg border border-border bg-card hover:bg-accent/50 transition-colors"
+						>
+							<div className="flex items-center gap-3">
+								<div className="h-8 w-8 rounded-lg bg-muted flex items-center justify-center">
+									<Users className="h-4 w-4 text-muted-foreground" />
+								</div>
+								<div>
+									<p className="text-sm font-medium text-foreground">
+										{team.name}
+									</p>
+									<p className="text-xs text-muted-foreground">
+										{team.org} | {team.members} members
+									</p>
+								</div>
+							</div>
+						</div>
+					))}
+				</div>
+			</CardContent>
+		</Card>
+	);
+}

--- a/apps/web/src/components/admin-panel/content-layout.tsx
+++ b/apps/web/src/components/admin-panel/content-layout.tsx
@@ -9,7 +9,7 @@ export function ContentLayout({ title, children }: ContentLayoutProps) {
 	return (
 		<div>
 			<Navbar title={title} />
-			<div className="container pt-8 pb-8 px-4 sm:px-8">{children}</div>
+			{children}
 		</div>
 	);
 }

--- a/apps/web/src/components/admin-panel/navbar.tsx
+++ b/apps/web/src/components/admin-panel/navbar.tsx
@@ -8,7 +8,7 @@ interface NavbarProps {
 
 export function Navbar({ title }: NavbarProps) {
 	return (
-		<header className="sticky top-0 z-10 w-full bg-background/95 shadow backdrop-blur supports-backdrop-filter:bg-background/60 dark:shadow-secondary">
+		<header className="sticky top-0 z-10 w-full bg-background shadow dark:shadow-secondary">
 			<div className="mx-4 sm:mx-8 flex h-14 items-center">
 				<div className="flex items-center space-x-4 lg:space-x-0">
 					<SheetMenu />

--- a/apps/web/src/lib/__mocks__/utils.ts
+++ b/apps/web/src/lib/__mocks__/utils.ts
@@ -1,0 +1,3 @@
+import { vi } from "vitest";
+
+export const capitalize = vi.fn((str: string) => "capitalized");

--- a/apps/web/src/lib/utils.test.ts
+++ b/apps/web/src/lib/utils.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it, test } from "vitest";
+import { capitalize, shouldShow } from "./utils";
+
+describe("shouldShow", () => {
+	describe("when user 'isAuthenticated' is true", () => {
+		const isAuthenticated = true;
+
+		it("should return true if 'showPublicSite' is true", () => {
+			const showPublicSite = true;
+			const result = shouldShow(isAuthenticated, showPublicSite);
+			expect(result).toBe(true);
+		});
+
+		it("should return false if 'showPublicSite' is false", () => {
+			const showPublicSite = false;
+			const result = shouldShow(isAuthenticated, showPublicSite);
+			expect(result).toBe(false);
+		});
+	});
+
+	describe("when user 'isAuthenticated' is false", () => {
+		const isAuthenticated = false;
+
+		it("should return true regardless of 'showPublicSite' value", () => {
+			const showPublicSiteTrue = true;
+			const showPublicSiteFalse = false;
+
+			const resultTrue = shouldShow(isAuthenticated, showPublicSiteTrue);
+			const resultFalse = shouldShow(isAuthenticated, showPublicSiteFalse);
+
+			expect(resultTrue).toBe(true);
+			expect(resultFalse).toBe(true);
+		});
+	});
+});
+
+describe("capitalize", () => {
+	it("should handle empty string", () => {
+		const result = capitalize("");
+		expect(result).toBe("");
+	});
+
+	it("should capitalize single lowercase letter", () => {
+		const result = capitalize("a");
+		expect(result).toBe("A");
+	});
+
+	it("should capitalize first letter of a word", () => {
+		const result = capitalize("test");
+		expect(result).toBe("Test");
+	});
+});

--- a/apps/web/src/lib/utils.ts
+++ b/apps/web/src/lib/utils.ts
@@ -14,3 +14,15 @@ export function shouldShow(
 	// 2. User is authenticated AND has enabled showPublicSite flag
 	return !isAuthenticated || (isAuthenticated && showPublicSite);
 }
+
+/**
+ * Capitalizes the first letter of a given string.
+ *
+ * @param str word to whose first letter needs to be capitalized
+ * @returns word with first letter in uppercase
+ */
+export function capitalize(str: string): string {
+	// Handle empty string case
+	if (str.length === 0) return str;
+	return str.charAt(0).toUpperCase() + str.slice(1);
+}

--- a/apps/web/vitest.setup.ts
+++ b/apps/web/vitest.setup.ts
@@ -17,6 +17,7 @@ vi.mock("@repo/shadcn/components/card");
 
 // Custom components
 vi.mock("@/components/admin-panel/admin-panel-layout");
+vi.mock("@/components/admin-panel/content-layout");
 
 // Lucide React icons
 vi.mock("lucide-react");

--- a/apps/web/vitest.setup.ts
+++ b/apps/web/vitest.setup.ts
@@ -13,6 +13,7 @@ vi.mock("@repo/shadcn/components/sheet");
 vi.mock("@repo/shadcn/components/button");
 vi.mock("@repo/shadcn/components/dropdown-menu");
 vi.mock("@repo/shadcn/components/avatar");
+vi.mock("@repo/shadcn/components/card");
 
 // Custom components
 vi.mock("@/components/admin-panel/admin-panel-layout");

--- a/packages/ui/shadcn/components/__mocks__/card.tsx
+++ b/packages/ui/shadcn/components/__mocks__/card.tsx
@@ -14,6 +14,12 @@ export const CardTitle = ({ children, ...props }: { children: React.ReactNode; c
 	</h3>
 );
 
+export const CardDescription = ({ children, ...props }: { children: React.ReactNode; className?: string }) => (
+	<p data-testid="card-description" {...props}>
+		{children}
+	</p>
+);
+
 export const CardContent = ({ children, ...props }: { children: React.ReactNode; className?: string }) => (
 	<div data-testid="card-content" {...props}>
 		{children}

--- a/packages/ui/shadcn/components/__mocks__/card.tsx
+++ b/packages/ui/shadcn/components/__mocks__/card.tsx
@@ -1,0 +1,21 @@
+export const Card = ({ children, ...props }: { children: React.ReactNode }) => (
+	<div data-testid="card-wrapper" {...props}>{children}</div>
+);
+
+export const CardHeader = ({ children, ...props }: { children: React.ReactNode; className?: string }) => (
+	<div data-testid="card-header" {...props}>
+		{children}
+	</div>
+);
+
+export const CardTitle = ({ children, ...props }: { children: React.ReactNode; className?: string }) => (
+	<h3 data-testid="card-title" {...props}>
+		{children}
+	</h3>
+);
+
+export const CardContent = ({ children, ...props }: { children: React.ReactNode; className?: string }) => (
+	<div data-testid="card-content" {...props}>
+		{children}
+	</div>
+);


### PR DESCRIPTION
This pull request introduces a new dashboard page for the internal web application, featuring a modular and testable design for displaying organizations, teams, projects, and statistics. It adds new card components for each dashboard section, implements a utility function for icon selection, and includes comprehensive unit tests and mocks to ensure component reliability.

**Dashboard Feature Implementation:**

- Added a new dashboard page (`page.tsx`) that displays statistics, organizations, teams, and projects using dedicated card components. The page uses mock data and a grid layout for a modern, responsive UI. A utility function `getIcon` maps dashboard sections to their respective icons.

**New Card Components:**

- Created `OrganizationsCard`, `TeamsCard`, `ProjectsCard`, and `StatsCard` components, each responsible for rendering a specific dashboard section with appropriate props and styling. Each card uses icons from `lucide-react` and supports dynamic data. [[1]](diffhunk://#diff-12a4c73fb1dec6f29b4d4fc871519a787823195a3fc3960c973f6046075962fcR1-R59) [[2]](diffhunk://#diff-d00a60291d271d7df8ecb3bc6c0983c09ee8e629a040fc40dc55392e9cfdec95R1-R59) [[3]](diffhunk://#diff-9efa651d1d1268aa49cc4d6f6b1f7e8f77d1d39cdce651ef26250beaa20e40ceR1-R59) [[4]](diffhunk://#diff-b62b2e21ea4beea709d89e118732ec2083051662e3f0f240e52ae38ff648eeebR1-R29)

**Testing and Mocks:**

- Added unit tests for the dashboard page and all card components to verify rendering and props handling. Mocks for card components and icons ensure isolated and reliable tests. [[1]](diffhunk://#diff-f8fdc52815a971cf30d5a3a680294e6c708a04e7a38c4573bbdaaf3d40235b36R1-R70) [[2]](diffhunk://#diff-8ff6d861497c38407cae75498bc0ee94b886a99b3644c6d3a15aa5db98fcf6eeR1-R44) [[3]](diffhunk://#diff-9149613ea70097065b609798ba71d3b5861793842b5cd1cff4ae920eaad679aeR1-R42) [[4]](diffhunk://#diff-7782500acebd71138e5f6d87c430c37cf0183f14a2f0878588384efc1397b904R1-R45) [[5]](diffhunk://#diff-e2c731cfc7eebe113eaf6d842efa13c5ca9be9cc8525d4e1cd6073b1c4899bdfR1-R15) [[6]](diffhunk://#diff-d8072493f42cafdc3c81537643108ab3268ee6f1513ec44bfcd79040ad3ee2b0R1-R7) [[7]](diffhunk://#diff-e588fa61998a43038dada4faaae2b66a339ec59685284fb31b6766a5311007f1R1-R7) [[8]](diffhunk://#diff-d013a9ed56fccfbe5b0d0efb851ae90eb14b10ab13fef7cb81f76fe5b88d1077R1-R7) [[9]](diffhunk://#diff-5b6b57c66f1df541217a243cb96c09f4db19575782132d8f6131f0b87dea3584R1-R7) [[10]](diffhunk://#diff-43fffaf732f3fbb05ca9925efad27ed87401bb174a62f703f11bad1258326ff6R35-R78)
- Provided a mock implementation for the `capitalize` utility in tests.

**Utilities and Supporting Changes:**

- Implemented and tested the `capitalize` and `shouldShow` utility functions for use throughout the dashboard and other components.

**Styling and Layout Adjustments:**

- Updated the `ContentLayout` and `Navbar` components to better accommodate the new dashboard design, removing unnecessary padding and backdrop blur for a cleaner look. [[1]](diffhunk://#diff-e63438139039c3902d8bf4f80132fceae239d60a534e0972f79a8bed727b6062L12-R12) [[2]](diffhunk://#diff-80afc782904c7c67fb0df39701d3d400ec7a0e99bfbb224ec02f301df28b47e0L11-R11)

---

**References:**
- Dashboard implementation and icon utility:
- Card components: [[1]](diffhunk://#diff-12a4c73fb1dec6f29b4d4fc871519a787823195a3fc3960c973f6046075962fcR1-R59) [[2]](diffhunk://#diff-d00a60291d271d7df8ecb3bc6c0983c09ee8e629a040fc40dc55392e9cfdec95R1-R59) [[3]](diffhunk://#diff-9efa651d1d1268aa49cc4d6f6b1f7e8f77d1d39cdce651ef26250beaa20e40ceR1-R59) [[4]](diffhunk://#diff-b62b2e21ea4beea709d89e118732ec2083051662e3f0f240e52ae38ff648eeebR1-R29)
- Tests and mocks: [[1]](diffhunk://#diff-f8fdc52815a971cf30d5a3a680294e6c708a04e7a38c4573bbdaaf3d40235b36R1-R70) [[2]](diffhunk://#diff-8ff6d861497c38407cae75498bc0ee94b886a99b3644c6d3a15aa5db98fcf6eeR1-R44) [[3]](diffhunk://#diff-9149613ea70097065b609798ba71d3b5861793842b5cd1cff4ae920eaad679aeR1-R42) [[4]](diffhunk://#diff-7782500acebd71138e5f6d87c430c37cf0183f14a2f0878588384efc1397b904R1-R45) [[5]](diffhunk://#diff-e2c731cfc7eebe113eaf6d842efa13c5ca9be9cc8525d4e1cd6073b1c4899bdfR1-R15) [[6]](diffhunk://#diff-d8072493f42cafdc3c81537643108ab3268ee6f1513ec44bfcd79040ad3ee2b0R1-R7) [[7]](diffhunk://#diff-e588fa61998a43038dada4faaae2b66a339ec59685284fb31b6766a5311007f1R1-R7) [[8]](diffhunk://#diff-d013a9ed56fccfbe5b0d0efb851ae90eb14b10ab13fef7cb81f76fe5b88d1077R1-R7) [[9]](diffhunk://#diff-5b6b57c66f1df541217a243cb96c09f4db19575782132d8f6131f0b87dea3584R1-R7) [[10]](diffhunk://#diff-43fffaf732f3fbb05ca9925efad27ed87401bb174a62f703f11bad1258326ff6R35-R78)
- Utility functions: [[1]](diffhunk://#diff-dfd373d1dff4d704b38185f49d4c5eeb43a86af1dc5320ede98a7cf6ae509c12R1-R52) [[2]](diffhunk://#diff-8044c02c1f7b4a09e20c4fd5c4426803e8af149a1cbf2dd5652d817fa5919e0fR1-R3)
- Layout and styling: [[1]](diffhunk://#diff-e63438139039c3902d8bf4f80132fceae239d60a534e0972f79a8bed727b6062L12-R12) [[2]](diffhunk://#diff-80afc782904c7c67fb0df39701d3d400ec7a0e99bfbb224ec02f301df28b47e0L11-R11)